### PR TITLE
Remove test for specific version of Drop-in script

### DIFF
--- a/src/test/java/service/CheckoutControllerTest.java
+++ b/src/test/java/service/CheckoutControllerTest.java
@@ -67,8 +67,7 @@ public class CheckoutControllerTest {
         mockMvc.perform(get("/checkouts"))
             .andExpect(view().name("checkouts/new"))
             .andExpect(model().hasNoErrors())
-            .andExpect(model().attributeExists("clientToken"))
-            .andExpect(xpath("//script[@src='https://js.braintreegateway.com/web/dropin/1.2.0/js/dropin.min.js']").exists());
+            .andExpect(model().attributeExists("clientToken"));
     }
 
     @Test


### PR DESCRIPTION
This allows us to use the script to update the Drop-in version more easily and is also not tested in any of the other example repos. Doesn't seem like we're losing too much here.