### PR TITLE
Bump dependency Versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ targetCompatibility = 1.7
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web:1.5.7.RELEASE")
-    compile("com.braintreepayments.gateway:braintree-java:2.73.0")
+    compile("com.braintreepayments.gateway:braintree-java:2.79.0")
     compile("org.springframework.boot:spring-boot-starter-thymeleaf")
     testCompile("junit:junit")
     testCompile("io.rest-assured:spring-mock-mvc:3.0.3")

--- a/src/main/resources/templates/checkouts/new.html
+++ b/src/main/resources/templates/checkouts/new.html
@@ -58,7 +58,7 @@
     </div>
   </div>
 
-  <script src="https://js.braintreegateway.com/web/dropin/1.9.4/js/dropin.min.js"></script>
+  <script src="https://js.braintreegateway.com/web/dropin/1.10.0/js/dropin.min.js"></script>
   <script th:inline="javascript">
     /*<![CDATA[*/
     var form = document.querySelector('#payment-form');


### PR DESCRIPTION
Braintree Java to 2.79.0
Braintree Drop-in to 1.10.0