### PR TITLE
Update dependency, Gradle and JDK versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk15
+  - openjdk17
 notifications:
   email: false
   slack:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM eclipse-temurin:17
 
 RUN apt-get update && apt-get install -y build-essential
 

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Sandbox transactions must be made with [sample credit card numbers](https://deve
 
 ## Disclaimer
 
-This code is provided as is and is only intended to be used for illustration purposes. This code is not production-ready and is not meant to be used  in a production environment. This repository is to be used as a tool to help merchants learn how to integrate with Braintree. Any use of this repository or any of its code in a production environment is highly discouraged.
+This code is provided as is and is only intended to be used for illustration purposes. This code is not production-ready and is not meant to be used in a production environment. This repository is to be used as a tool to help merchants learn how to integrate with Braintree. Any use of this repository or any of its code in a production environment is highly discouraged.

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.3.2.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.7.3")
     }
 }
 
@@ -15,27 +15,33 @@ apply plugin: 'org.springframework.boot'
 jar {
     archiveBaseName = 'bt-example'
     archiveVersion =  '0.1.0'
+    archiveClassifier = ""
+    manifest {
+        attributes(
+                'Main-Class': 'springexample.Application'
+        )
+    }
 }
 
 repositories {
     mavenCentral()
 }
 
-sourceCompatibility = 1.15
-targetCompatibility = 1.15
+sourceCompatibility = 1.17
+targetCompatibility = 1.17
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web:2.3.2.RELEASE")
-    implementation("com.braintreepayments.gateway:braintree-java:3.0.0")
-    implementation("org.springframework.boot:spring-boot-starter-thymeleaf:2.3.2.RELEASE")
-    testImplementation("junit:junit")
-    testImplementation("io.rest-assured:spring-mock-mvc:4.3.1")
-    testImplementation("org.springframework.boot:spring-boot-starter-test:2.3.2.RELEASE")
-    testImplementation("com.braintreepayments.gateway:braintree-java:3.0.0")
+    implementation('org.springframework.boot:spring-boot-starter-web:2.7.3')
+    implementation('com.braintreepayments.gateway:braintree-java:3.18.0')
+    implementation('org.springframework.boot:spring-boot-starter-thymeleaf:2.7.3')
+    testImplementation("junit:junit:4.13.2")
+    testImplementation('io.rest-assured:spring-mock-mvc:5.1.1')
+    testImplementation('org.springframework.boot:spring-boot-starter-test:2.7.3')
+    testImplementation('com.braintreepayments.gateway:braintree-java:3.18.0')
 }
 
 wrapper {
-    gradleVersion = '6.5.1'
+    gradleVersion = '7.5.1'
 }
 
 task stage (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '2'
 services:
   web:
     build: .
-    command: java -Dserver.port=4567 -jar ./build/libs/bt-example-0.1.0.jar
+    command: java -Dserver.port=4567 -jar ./build/libs/braintree_spring_example.jar
     ports:
       - "4567:4567"
-    volumes:
-      - .:/braintree_spring_example

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=15
+java.runtime.version=17


### PR DESCRIPTION
This should solve #30 which was caused by the Gradle wrapper version being incompatible with JDK > 14 [according to the gradle docs](https://docs.gradle.org/current/userguide/compatibility.html).

While I was here, I bumped the various dependencies, made sure Travis also used a matching JDK (though I'm not 100% Travis even runs anymore?), and fixed some weird issues with the dockerfile/docker compose setup.  After setting your API keys as called out in the readme, you should be able to set up the example via local docker in one shot via `docker compose up` (or `docker-compose up` prior to Compose V2).

The only thing I have not personally checked is the Heroku button, however that should be fixed by using a compatible Gradle version. It was set to JDK 15 for some reason which was incompatible with the Gradle version (explained above), but bumping the `system.properties` to again match the other configurations and bumping Gradle should mean "it just works".